### PR TITLE
Fix a potential crash in audio decoding

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -24,6 +24,7 @@ type AudioStream struct {
 	baseStream
 	swrCtx *C.SwrContext
 	buffer *C.uint8_t
+	bufferSize C.int
 }
 
 // ChannelCount returns the number of channels
@@ -109,9 +110,15 @@ func (audio *AudioStream) ReadAudioFrame() (*AudioFrame, bool, error) {
 			"%d: couldn't get the max buffer size", maxBufferSize)
 	}
 
+	if maxBufferSize > audio.bufferSize {
+		C.av_free(unsafe.Pointer(audio.buffer))
+		audio.buffer = nil
+	}
+
 	if audio.buffer == nil {
 		audio.buffer = (*C.uint8_t)(unsafe.Pointer(
 			C.av_malloc(bufferSize(maxBufferSize))))
+		audio.bufferSize = maxBufferSize
 
 		if audio.buffer == nil {
 			return nil, false, fmt.Errorf(


### PR DESCRIPTION
Random heap corruptions would happen whenever an audio frame required a buffer larger than the previously allocated one. Fixes #12.