### PR TITLE
Use pkg-config to determine correct compile/link flags

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -1,6 +1,6 @@
 package reisen
 
-// #cgo LDFLAGS: -lavutil -lavformat -lavcodec -lswresample
+// #cgo pkg-config: libavformat libavcodec libavutil libswresample
 // #include <libavcodec/avcodec.h>
 // #include <libavformat/avformat.h>
 // #include <libavutil/avutil.h>
@@ -22,8 +22,8 @@ const (
 // audio frames consisting of audio samples.
 type AudioStream struct {
 	baseStream
-	swrCtx *C.SwrContext
-	buffer *C.uint8_t
+	swrCtx     *C.SwrContext
+	buffer     *C.uint8_t
 	bufferSize C.int
 }
 

--- a/interpolation.go
+++ b/interpolation.go
@@ -1,6 +1,6 @@
 package reisen
 
-// #cgo LDFLAGS: -lswscale
+// #cgo pkg-config: libswscale
 // #include <libswscale/swscale.h>
 import "C"
 

--- a/media.go
+++ b/media.go
@@ -1,6 +1,6 @@
 package reisen
 
-// #cgo LDFLAGS: -lavformat -lavcodec -lavutil -lswscale
+// #cgo pkg-config: libavformat libavcodec libavutil libswscale
 // #include <libavcodec/avcodec.h>
 // #include <libavformat/avformat.h>
 // #include <libavutil/avconfig.h>

--- a/packet.go
+++ b/packet.go
@@ -1,6 +1,6 @@
 package reisen
 
-// #cgo LDFLAGS: -lavformat -lavcodec -lavutil -lswscale
+// #cgo pkg-config: libavformat libavcodec libavutil libswscale
 // #include <libavcodec/avcodec.h>
 // #include <libavformat/avformat.h>
 // #include <libavutil/avconfig.h>

--- a/stream.go
+++ b/stream.go
@@ -1,6 +1,6 @@
 package reisen
 
-// #cgo LDFLAGS: -lavutil -lavformat -lavcodec
+// #cgo pkg-config: libavutil libavformat libavcodec
 // #include <libavcodec/avcodec.h>
 // #include <libavformat/avformat.h>
 // #include <libavutil/avconfig.h>

--- a/time.go
+++ b/time.go
@@ -1,6 +1,6 @@
 package reisen
 
-// #cgo LDFLAGS: -lavutil
+// #cgo pkg-config: libavutil
 // #include <libavutil/avutil.h>
 import "C"
 

--- a/video.go
+++ b/video.go
@@ -1,6 +1,6 @@
 package reisen
 
-// #cgo LDFLAGS: -lavutil -lavformat -lavcodec -lswscale
+// #cgo pkg-config: libavutil libavformat libavformat  libswscale
 // #include <libavcodec/avcodec.h>
 // #include <libavformat/avformat.h>
 // #include <libavutil/avutil.h>


### PR DESCRIPTION
This fixes build on the recent Mac OS installations where HomeBrew doesn't have libav anymore.